### PR TITLE
Strict mode for rubberduck to guarantee method.length is unchanged

### DIFF
--- a/lib/rubberduck.js
+++ b/lib/rubberduck.js
@@ -1,5 +1,29 @@
 var events = require('events');
 
+function toBase26(num) {
+	var outString = '';
+	var letters = 'abcdefghijklmnopqrstuvwxyz';
+	while(num > 25) {
+		var remainder = num % 26;
+		outString = letters.charAt(remainder) + outString;
+		num = Math.floor(num / 26) - 1;
+	}
+    outString = letters.charAt(num) + outString;
+	return outString;
+}
+
+function makeFakeArgs(len) {
+	var argArr = [];
+	for(var i = 0; i < len; i++) {
+		argArr.push(toBase26(i));
+	}
+	return argArr.join(",");
+}
+
+function addArgs(fnString, argLen)  {
+	return fnString.replace(/function\s*\(\)/, 'function('+makeFakeArgs(argLen)+')');
+}
+
 var wrap = exports.wrap = {
 	/**
 	 * Wrap an anonymous or named function to notify an Emitter and
@@ -8,11 +32,11 @@ var wrap = exports.wrap = {
 	 * @param {Function} fn The function to wrap
 	 * @param {String} name The optional name
 	 */
-	fn : function(emitter, fn, name, scope) {
+	fn : function(emitter, fn, strict, name, scope) {
 		var ucName = name ? name.replace(/^\w/, function($0) {
 			return $0.toUpperCase();
 		}) : null;
-		return function() {
+		var wrapped = function() {
 			var result;
 			emitter.emit('before', arguments, this, name);
 			ucName && emitter.emit('before' + ucName, arguments, this, name);
@@ -26,7 +50,9 @@ var wrap = exports.wrap = {
 			ucName && emitter.emit('after' + ucName, result, arguments, this, name);
 			emitter.emit('after', result, arguments, this, name);
 			return result;
-		}
+		};
+		if(strict) eval('wrapped = ' + addArgs(wrapped.toString(), fn.length));
+		return wrapped;
 	},
 	/**
 	 * Wrap an anonymous or named function that calls a callback asynchronously
@@ -37,11 +63,11 @@ var wrap = exports.wrap = {
 	 * array (defaults to 0). Set to -1 if the callback is the last argument.
 	 * @param {String} name The optional name
 	 */
-	async : function(emitter, fn, position, name, scope) {
+	async : function(emitter, fn, position, strict, name, scope) {
 		var ucName = name ? name.replace(/^\w/, function($0) {
 			return $0.toUpperCase();
 		}) : null;
-		return function() {
+		var wrapped = function() {
 			var pos = position == -1 ? arguments.length - 1 : (position || 0), //
 			callback = arguments[pos], context = this, methodArgs = arguments, //
 			callbackWrapper = function() {
@@ -66,7 +92,9 @@ var wrap = exports.wrap = {
 				emitter.emit('error', e, arguments, context, name);
 				throw e;
 			}
-		}
+		};
+		if(strict) eval('wrapped = ' + addArgs(wrapped.toString(), fn.length));
+		return wrapped;
 	}
 };
 
@@ -83,18 +111,18 @@ Emitter.prototype = Object.create(events.EventEmitter.prototype);
  * @param {Integer} position The optional position of the asynchronous callback
  * in the arguments list.
  */
-Emitter.prototype.punch = function(method, position) {
+Emitter.prototype.punch = function(method, position, strict) {
 	if(Array.isArray(method)) {
 		var self = this;
 		method.forEach(function(method) {
-			self.punch(method);
+			self.punch(method, position, strict);
 		});
 	} else {
 		var old = this.obj[method];
 		if( typeof old == 'function') {
 			this.obj[method] = (!position && position !== 0) ?
-				wrap.fn(this, old, method) :
-				wrap.async(this, old, position, method)
+				wrap.fn(this, old, strict, method) :
+				wrap.async(this, old, position, strict, method)
 		}
 	}
 	return this;

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,13 @@ and after the callback occurs. These methods fire ``error`` and ``errorMethod`` 
 of the ``after`` and ``afterMethod`` events. Asynchronous methods that return an ``Error``
 object as the first argument to the callback will also fire error-type events rather than after.
 
+## Strict punched methods
+
+A second optional parameter to ``punch`` (the third argument) is a flag indicating whether or not
+rubberduck should be strict with the signature of the resulting function. This means the ``length``
+property of any punched method will remain the same (rather than revert to zero), at the cost of
+a slightly more expensive mechanism to punch the methods, and is off by default.
+
 ## License
 
 Copyright (C) 2011 David Luecke daff@neyeon.de

--- a/test/duck.test.js
+++ b/test/duck.test.js
@@ -86,3 +86,26 @@ exports.duckPunchThrow = function(test)
 		if(err instanceof Error) test.ok(true, 'got the error object');
 	});
 };
+
+exports.duckPunchStrict = function(test) {
+	test.expect(3);
+	var obj = {
+		number: 42,
+		zeroLen: function() {
+			return this.number;
+		},
+		oneLen: function(val) {
+			return val + this.number;
+		},
+		twoLen: function(val1, val2) {
+			return this.number * val1 / val2;
+		}
+	};
+
+	var emitter = duck.emitter(obj).punch(['zeroLen', 'oneLen', 'twoLen'], null, true);
+
+	test.equal(obj.zeroLen.length, 0, 'zeroLen stays with zero args');
+	test.equal(obj.oneLen.length, 1, 'oneLen keeps its argument length');
+	test.equal(obj.twoLen.length, 2, 'twoLen also keeps its arg len. In zero, one, many context, this should now work perfectly');
+	test.done();
+};

--- a/test/wrap.fn.test.js
+++ b/test/wrap.fn.test.js
@@ -35,7 +35,7 @@ exports.wrapNamed = function (test) {
 		return 'testing';
 	}
 	
-	var wrapped = duck.wrap.fn(emitter, fn, 'quack');
+	var wrapped = duck.wrap.fn(emitter, fn, false, 'quack');
 	
 	emitter.on('before', function(args, context, method) {
 		test.equal(args[0], 'test');
@@ -72,7 +72,7 @@ exports.wrapScope = function (test) {
 	
 	emitter = new events.EventEmitter();
 	
-	var wrapped = duck.wrap.fn(emitter, obj.method, 'method', obj);
+	var wrapped = duck.wrap.fn(emitter, obj.method, false, 'method', obj);
 	
 	emitter.on('after', function(result) {
 		test.equal(result, 42);


### PR DESCRIPTION
Here's the patch for a strict mode. I added it as a new argument, but if you'd prefer, I could merge it with the other optional argument into an `options` object to avoid the need to pass `null` or `undefined` if the user wants to enable strict mode for a sync function.
