### PR TITLE
wrapAsync should still return the original value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
+sudo: false
 language: node_js
-node_js:
-  - 0.10
-  - 0.11
+node_js: node

--- a/lib/rubberduck.js
+++ b/lib/rubberduck.js
@@ -60,7 +60,7 @@ var wrap = exports.wrap = {
       methodArgs[pos] = callbackWrapper;
 
       try {
-        fn.apply(scope || this, methodArgs);
+        return fn.apply(scope || this, methodArgs);
       } catch (e) {
         utils.emitEvents(emitter, 'error', name, [ e, methodArgs, context, name ]);
         throw e;

--- a/test/wrap.async.test.js
+++ b/test/wrap.async.test.js
@@ -3,12 +3,13 @@ var duck = require('../lib/rubberduck');
 var events = require('events');
 
 describe('Asynchronous function wrapping', function() {
-  it('wraps asynchronous function', function(done) {
+  it('wraps asynchronous function but returns its value', function(done) {
     var emitter = new events.EventEmitter();
 
     var asyncFn = function(cb) {
       assert.ok(true, 'Fn called');
       cb('testing');
+      return true;
     };
 
     var wrapped = duck.wrap.async(emitter, asyncFn);
@@ -27,7 +28,7 @@ describe('Asynchronous function wrapping', function() {
       done();
     });
 
-    wrapped(callback, 42);
+    assert.ok(wrapped(callback, 42));
   });
 
   it('wraps async test with callback at the end', function(done) {


### PR DESCRIPTION
`wrapAsync` did not return the functions initial value. That isn't always a problem because functions with a callback generally don't return a value but it is when you want to e.g. support both, promises and callbacks.